### PR TITLE
Fix for worker stop

### DIFF
--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -76,7 +76,7 @@ class RemoteServiceBase:
     """
     # Incoming messages larger than 1 MiB are dropped to avoid DOS
     # attacks. XXX Check that this size is sensible.
-    MAX_MESSAGE_SIZE = 1024 * 1024
+    MAX_MESSAGE_SIZE = 1024 * 1024 * 1024
 
     def __init__(self, remote_address):
         """Prepare to handle a connection with the given remote address.


### PR DESCRIPTION
By increasing MAX_MESSAGE_SIZE to 1GB the workers are able to handle submissions with a print of more than 1 billion characters.